### PR TITLE
revert(cloudflared): drop dnsPolicy=None override

### DIFF
--- a/kubernetes/infrastructure/controllers/cloudflared/app/helm-release.yaml
+++ b/kubernetes/infrastructure/controllers/cloudflared/app/helm-release.yaml
@@ -75,14 +75,6 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-      # CoreDNS upstream returns compressed SRV records for
-      # _v2-origintunneld._tcp.argotunnel.com, which Go's resolver rejects
-      # (golang/go#27546). Bypass CoreDNS for cloudflared's external lookups.
-      dnsPolicy: None
-      dnsConfig:
-        nameservers:
-          - 1.1.1.1
-          - 1.0.0.1
     service:
       app:
         controller: cloudflared


### PR DESCRIPTION
## Summary
- Reverts f26efe6, which set `dnsPolicy: None` + `nameservers: [1.1.1.1, 1.0.0.1]` on cloudflared as a speculative workaround for golang/go#27546.
- That Go resolver bug was fixed in Go 1.12 (2019); cloudflared 2026.3.0 ships a modern Go runtime. Argotunnel SRV response is 156 bytes — nowhere near CoreDNS's 1232-byte bufsize cap, so no compression path is even triggered.
- The override broke in-cluster Service resolution: cloudflared could not resolve `router-grappleberry.openshift-ingress.svc.cluster.local` via 1.1.1.1, producing **502 Bad Gateway** for every externally-proxied hostname (overseerr, sonarr, radarr, …). Secondary `i/o timeout` errors reaching 1.1.1.1 from cluster egress caused sporadic tunnel flapping.

## Verification
- Live-patched the Deployment to `dnsPolicy: ClusterFirst`; all 4 QUIC edge connections registered cleanly (nrt14, dxb01, fra17, ams18). Zero SRV/DNS errors.
- `curl https://overseerr.grappleberry.xyz/` → HTTP 200, full Sign-In page served through the tunnel.

## Test plan
- [x] New cloudflared pods reach Cloudflare edge via CoreDNS (verified in logs)
- [x] External `*.grappleberry.xyz` hostnames return 200 through the tunnel
- [ ] After merge, resume the cloudflared Kustomization (currently suspended to hold the live fix): `flux resume kustomization -n flux-system cloudflared`