### PR TITLE
feat(storage): released-pv reaper, ceph-block Delete policy, mon-disk proposal

### DIFF
--- a/docs/mon-disk-proposal.md
+++ b/docs/mon-disk-proposal.md
@@ -1,0 +1,86 @@
+# Proposal: dedicated mon disk per master (retire MON_DISK_LOW structurally)
+
+Status: proposal, not applied. No live changes in this PR.
+
+## Problem
+
+Ceph reports `MON_DISK_LOW` recurrently (mon.f at 18% avail, mon.g at 21% as
+of 2026-07-26). The mon stores live under `/var/lib/rook` on each master's
+root disk, which they share with the OS image store, container layers, logs,
+and everything else kubelet does. Two commits have already lowered kubelet
+image-GC thresholds to 70% to keep mon stores breathing — that is
+symptom-tuning, and two commits deep is where a stopgap starts becoming
+load-bearing. The mon store does not need much space; it needs space that
+*nothing else can eat*.
+
+## Proposal
+
+Give each master a small dedicated virtual disk and mount it at
+`/var/lib/rook`.
+
+### 1. Disk (Terraform / okdctl, per master VM)
+
+- Add a third SCSI disk per master in the Proxmox VM definition:
+  `drive-scsi2`, 20 GiB (mon stores run low single-digit GiB; 20 GiB absorbs
+  compaction spikes and recovery growth with room to spare).
+- The device path is deterministic the same way the OSD disk already is:
+  `/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi2`
+  (SCSI bus assignment is stable per Terraform disk-block order — same
+  mechanism the rook `devicePathFilter` relies on for `drive-scsi1`).
+- Live Terraform state is on the bastion; this pairs naturally with the
+  okdctl node-resize/lifecycle work, which exists for exactly this kind of
+  change.
+
+### 2. Filesystem + mount (MachineConfig)
+
+Ignition's `storage.disks`/`filesystems` sections only run on first boot, so
+for the three *existing* masters the format step is manual (one-time, per
+master):
+
+    mkfs.xfs -L rookmon /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi2
+
+Delivery of the mount is declarative: a `99-master-rook-mon-disk` MC with a
+systemd mount unit for `/var/lib/rook` (`What=/dev/disk/by-label/rookmon`,
+`Before=kubelet.service`, `nofail` omitted deliberately — if the disk is
+gone we want the mon pod failing loudly, not writing to the root disk
+behind the mount point). New masters provisioned later get the full
+disks/filesystems treatment in ignition via okdctl instead.
+
+### 3. Migration (one master at a time, quorum-safe)
+
+Do not copy mon stores. Mons rebuild their store from quorum peers, so the
+clean sequence per master is:
+
+1. Verify `ceph status`: 3/3 mons in quorum, all PGs `active+clean`.
+2. Scale down the rook operator; delete the local mon deployment (e.g.
+   `mon.d`) so the node's mon is down — quorum holds at 2/3.
+3. Mount the new disk at `/var/lib/rook` (apply the MC / mount by hand for
+   the pilot node). Preserve `/var/lib/rook/rook-ceph` cluster metadata by
+   copying it onto the new disk first — it is tiny; only the mon store is
+   heavyweight.
+4. Scale the operator back up; it recreates the mon, which syncs a fresh
+   store onto the empty disk.
+5. Wait for 3/3 quorum and `active+clean`, then move to the next master.
+
+Total exposure per master is one mon down for minutes — the same exposure
+every MCO reboot already exercises weekly.
+
+### Rejected alternatives
+
+- **Keep tuning kubelet GC**: whack-a-mole; the mon still shares a device
+  with an unbounded consumer, and the 70% threshold already trades image
+  cache hit-rate for mon headroom.
+- **Enlarge the root disks** (okdctl node-resize): buys time, not isolation;
+  MON_DISK_LOW returns the day the image store grows into the new space.
+  Acceptable fallback if adding disks proves annoying, but it re-arms the
+  same alarm.
+- **Move mons to PVCs (rook `volumeClaimTemplate`)**: mons on ceph-backed
+  storage is a circular dependency; mons on `local-path` PVs is the same
+  disk with extra steps. A raw dedicated disk is simpler and honest.
+
+## Definition of done
+
+- `MON_DISK_LOW` cannot recur without the mon store itself growing 10x.
+- The two image-GC kubeletconfigs (`master-image-gc`, `worker-image-gc`)
+  get reverted — the stopgap is demolished the same week the fix lands,
+  per the standing rule that every migration includes its demolition step.

--- a/kubernetes/apps/rook-ceph/released-pv-reaper/app/cronjob.yaml
+++ b/kubernetes/apps/rook-ceph/released-pv-reaper/app/cronjob.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/cronjob_v1.json
+---
+# reaps Released ceph PVs so their RBD/CephFS images stop pinning space on a
+# pool that is already >40% raw-full. ceph-block was Retain-by-default with no
+# reaper, which left ~493 Released PVs (vs 28 Bound) each holding a dead image.
+#
+# how it deletes: it PATCHES persistentVolumeReclaimPolicy to Delete rather
+# than deleting the PV object. deleting a Retain PV outright would remove the
+# API object but ORPHAN the backing image (the CSI driver is never told);
+# flipping the policy makes the PV controller drive a proper CSI DeleteVolume,
+# which removes the image and then the PV. that is the entire point: reclaim
+# space, not hide corpses.
+#
+# safety rails, in order:
+#   - only PVs in phase=Released (claim already deleted by definition)
+#   - only ceph CSI volumes (spec.csi.driver *.csi.ceph.com)
+#   - claimRef PVC must not exist, or must not reference this PV, in case a
+#     same-name PVC was recreated
+#   - annotate a PV with released-pv-reaper.grappleberry.xyz/keep to exempt it
+#   - at most MAX_PER_RUN per run, so the 493-deep backlog drains gradually
+#     instead of hammering ceph with hundreds of image deletions at once
+#
+# to run one supervised pass:
+#   oc -n rook-ceph create job released-pv-reaper-manual --from=cronjob/released-pv-reaper
+#   oc -n rook-ceph logs -f job/released-pv-reaper-manual
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: released-pv-reaper
+spec:
+  schedule: "30 4 * * *"
+  timeZone: Asia/Dubai
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          serviceAccountName: released-pv-reaper
+          restartPolicy: Never
+          containers:
+            - name: reaper
+              image: quay.io/openshift/origin-cli:4.22
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: MAX_PER_RUN
+                  value: "50"
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  reaped=0
+                  skipped=0
+                  for pv in $(oc get pv -o go-template='{{range .items}}{{if eq .status.phase "Released"}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'); do
+                    if [ "${reaped}" -ge "${MAX_PER_RUN}" ]; then
+                      echo "reap limit ${MAX_PER_RUN} reached, remaining backlog drains on the next run"
+                      break
+                    fi
+                    keep=$(oc get pv "${pv}" -o go-template='{{index .metadata.annotations "released-pv-reaper.grappleberry.xyz/keep"}}' 2>/dev/null || true)
+                    if [ -n "${keep}" ] && [ "${keep}" != "<no value>" ]; then
+                      echo "SKIP ${pv}: keep annotation set"
+                      skipped=$((skipped+1))
+                      continue
+                    fi
+                    driver=$(oc get pv "${pv}" -o jsonpath='{.spec.csi.driver}')
+                    case "${driver}" in
+                      *.csi.ceph.com) ;;
+                      *)
+                        echo "SKIP ${pv}: driver '${driver:-none}' is not ceph csi"
+                        skipped=$((skipped+1))
+                        continue
+                        ;;
+                    esac
+                    ns=$(oc get pv "${pv}" -o jsonpath='{.spec.claimRef.namespace}')
+                    name=$(oc get pv "${pv}" -o jsonpath='{.spec.claimRef.name}')
+                    if [ -n "${ns}" ] && [ -n "${name}" ]; then
+                      bound_to=$(oc -n "${ns}" get pvc "${name}" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+                      if [ "${bound_to}" = "${pv}" ]; then
+                        echo "SKIP ${pv}: pvc ${ns}/${name} still references it"
+                        skipped=$((skipped+1))
+                        continue
+                      fi
+                    fi
+                    echo "REAP ${pv} (was claimed by ${ns:-?}/${name:-?}): flipping reclaim policy to Delete"
+                    oc patch pv "${pv}" --type=merge -p '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+                    reaped=$((reaped+1))
+                  done
+                  echo "done: reaped ${reaped}, skipped ${skipped}"
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi

--- a/kubernetes/apps/rook-ceph/released-pv-reaper/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/released-pv-reaper/app/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./rook-ceph-cluster
-  - ./released-pv-reaper
+  - ./rbac.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/rook-ceph/released-pv-reaper/app/rbac.yaml
+++ b/kubernetes/apps/rook-ceph/released-pv-reaper/app/rbac.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/serviceaccount.json
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: released-pv-reaper
+
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrole_v1.json
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: released-pv-reaper
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get"]
+
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: released-pv-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: released-pv-reaper
+subjects:
+  - kind: ServiceAccount
+    name: released-pv-reaper
+    namespace: rook-ceph

--- a/kubernetes/apps/rook-ceph/released-pv-reaper/ks.yaml
+++ b/kubernetes/apps/rook-ceph/released-pv-reaper/ks.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: released-pv-reaper
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: released-pv-reaper
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./kubernetes/apps/rook-ceph/released-pv-reaper/app
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/rook-ceph/released-pv-reaper/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/released-pv-reaper/kustomization.yaml
@@ -3,5 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./rook-ceph-cluster
-  - ./released-pv-reaper
+  - ./ks.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
@@ -113,7 +113,13 @@ spec:
           enabled: true
           name: ceph-block
           isDefault: true
-          reclaimPolicy: Retain
+          # Delete, not Retain: volsync restic to the NAS is the tested undo
+          # button; Retain-by-default with no reaper piled up ~493 Released
+          # PVs pinning dead RBD images. reclaimPolicy is immutable on a live
+          # StorageClass -- after merging, run `oc delete sc ceph-block` once
+          # and let the helm remediation recreate it (existing PVs and PVCs
+          # are untouched; the policy lives on each PV, not the class).
+          reclaimPolicy: Delete
           allowVolumeExpansion: true
           volumeBindingMode: Immediate
           mountOptions:


### PR DESCRIPTION
Implements the storage-hygiene items from the architecture review (docs/fable-architecture-opinion.md §2).

## What

- **released-pv-reaper cronjob** (rook-ceph ns, daily 04:30 GST): drains the 493 Released PVs and keeps the class clean going forward. It patches `persistentVolumeReclaimPolicy` to `Delete` rather than deleting PV objects -- deleting a Retain PV would silently orphan the backing RBD image; the policy flip drives a real CSI `DeleteVolume` so the space actually comes back. Guards: `phase=Released` only, ceph CSI drivers only, claimRef PVC must be gone or bound elsewhere, `released-pv-reaper.grappleberry.xyz/keep` annotation opt-out, max 50/run (backlog drains over ~10 days instead of hammering ceph once).
- **ceph-block reclaimPolicy Retain → Delete**: volsync restic to the NAS is the tested undo button; Retain-with-no-reaper was the worst of both worlds. **One-time step after merge**: `reclaimPolicy` is immutable on a live StorageClass, so the helm upgrade will error until you `oc delete sc ceph-block` once; remediation recreates it with `Delete`. Existing PVs/PVCs are untouched (policy is stamped per-PV at provision time).
- **docs/mon-disk-proposal.md**: dedicated 20GiB virtual disk per master for `/var/lib/rook` to retire MON_DISK_LOW structurally (mon.f/g at 18%/21% avail today), with a quorum-safe one-master-at-a-time migration and a demolition step for the image-GC stopgaps. Proposal only, no live change.

## Already done live (2026-07-26)

CRUSH ghost hosts `grappleberry-worker{0,1,2}-*` removed (`ceph osd crush rm` x3) after verifying 3/3 mons in quorum, 3/3 OSDs up, 169/169 PGs active+clean, and 0 OSDs under each ghost bucket. `ceph osd tree` is now three master hosts, nothing else -- single-node reboots will no longer report the absurd "4 hosts down".

## Suggested first-run supervision

    oc -n rook-ceph create job released-pv-reaper-manual --from=cronjob/released-pv-reaper
    oc -n rook-ceph logs -f job/released-pv-reaper-manual

then watch `oc get pv | grep -c Released` fall and `ceph df` recover space.