### PR TITLE
feat(observability): physical nvme smart health via smartctl_exporter on the proxmox host

### DIFF
--- a/kubernetes/apps/observability/smartctl-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-instance
-  - ./smartctl-exporter
+  - ./service.yaml
+  - ./service-monitor.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: smartctl-exporter-rules
+spec:
+  groups:
+    - name: smartctl-exporter.rules
+      rules:
+        - alert: SmartDeviceHealthFailed
+          expr: |-
+            smartctl_device_smart_status{namespace="observability"} != 1
+          for: 5m
+          annotations:
+            summary: >-
+              SMART overall-health check FAILED on {{ $labels.device }} -- the disk under the entire cluster is dying, verify NAS backups now
+          labels:
+            severity: critical
+        - alert: NvmeCriticalWarning
+          expr: |-
+            smartctl_device_critical_warning{namespace="observability"} > 0
+          for: 5m
+          annotations:
+            summary: >-
+              NVMe critical warning bits set on {{ $labels.device }} (spare/temperature/degraded/read-only)
+          labels:
+            severity: critical
+        - alert: NvmeWearoutHigh
+          expr: |-
+            smartctl_device_percentage_used{namespace="observability"} > 80
+          for: 1h
+          annotations:
+            summary: >-
+              NVMe {{ $labels.device }} has consumed {{ $value }}% of rated endurance -- plan a replacement
+          labels:
+            severity: warning
+        - alert: NvmeSpareLow
+          expr: |-
+            smartctl_device_available_spare{namespace="observability"}
+              <= on (device, instance)
+            smartctl_device_available_spare_threshold{namespace="observability"}
+          for: 15m
+          annotations:
+            summary: >-
+              NVMe {{ $labels.device }} available spare is at or below its threshold
+          labels:
+            severity: critical
+        - alert: NvmeMediaErrorsIncreasing
+          expr: |-
+            increase(smartctl_device_media_errors{namespace="observability"}[24h]) > 0
+          annotations:
+            summary: >-
+              NVMe {{ $labels.device }} logged new media errors in the last 24h
+          labels:
+            severity: warning
+        - alert: SmartctlExporterDown
+          expr: |-
+            absent(up{job="smartctl-exporter", namespace="observability"} == 1)
+          for: 30m
+          annotations:
+            summary: >-
+              smartctl_exporter on the proxmox host is unreachable -- NVMe death is currently invisible (install/repair it; see the service manifest header)
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/smartctl-exporter/app/service-monitor.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/service-monitor.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: smartctl-exporter
+spec:
+  endpoints:
+    - port: metrics
+      interval: 60s
+      scrapeTimeout: 30s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smartctl-exporter

--- a/kubernetes/apps/observability/smartctl-exporter/app/service.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/service.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/service.json
+---
+# scrape target for smartctl_exporter running ON THE PROXMOX HOST (.195), not
+# in the cluster. an in-VM smartctl daemonset would be blind: the masters see
+# QEMU virtio-scsi disks with no SMART passthrough (the same reason
+# diskprediction_local is disabled in the rook helm values). the one hardware
+# failure that kills all three replicas and etcd at once is the host NVMe,
+# so its health has to be scraped from the host itself.
+#
+# host side (one-time, on proxmox.grappleberry.xyz):
+#   1. download smartctl_exporter (v0.14.x) from
+#      https://github.com/prometheus-community/smartctl_exporter/releases
+#      into /usr/local/bin/smartctl_exporter
+#   2. systemd unit running:
+#        /usr/local/bin/smartctl_exporter --web.listen-address=:9633
+#      (needs root for smartctl device access)
+#   3. verify: curl http://192.168.227.195:9633/metrics | grep smartctl_device
+# the SmartctlExporterDown alert pages until this is done -- deliberately.
+apiVersion: v1
+kind: Service
+metadata:
+  name: smartctl-exporter
+  labels:
+    app.kubernetes.io/name: smartctl-exporter
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9633
+      protocol: TCP
+      targetPort: 9633
+
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/endpoints.json
+---
+# manual endpoints (no selector on the service): the target is the proxmox
+# host, outside the cluster. the endpointslice mirroring controller converts
+# this for discovery automatically.
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: smartctl-exporter
+  labels:
+    app.kubernetes.io/name: smartctl-exporter
+subsets:
+  - addresses:
+      - ip: 192.168.227.195
+    ports:
+      - name: metrics
+        port: 9633
+        protocol: TCP

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smartctl-exporter
+  namespace: flux-system
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: smartctl-exporter
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./kubernetes/apps/observability/smartctl-exporter/app
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/observability/smartctl-exporter/kustomization.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/kustomization.yaml
@@ -3,5 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-instance
-  - ./smartctl-exporter
+  - ./ks.yaml


### PR DESCRIPTION
Implements the disk-health item from the architecture review (docs/fable-architecture-opinion.md §3 item 8): the host NVMe is the one failure that kills all three Ceph replicas and etcd at once, and it currently has zero leading indicators.

## Approach note (changed from the obvious design)

A smartctl_exporter **DaemonSet on the masters would be blind**: the VMs see `QEMU HARDDISK` virtio-scsi devices with no SMART passthrough (verified with `lsblk -d -o MODEL,TRAN` on master0; it's also the documented reason `diskprediction_local` is disabled in the rook values). The exporter has to run on the Proxmox host (`proxmox.grappleberry.xyz`, .195). This PR ships the cluster side:

- selectorless Service + manual Endpoints -> `192.168.227.195:9633`
- ServiceMonitor (UWM, observability ns, 60s interval)
- PrometheusRules: SMART health failed, NVMe critical-warning bits, endurance >80% used, available-spare at threshold, new media errors in 24h
- **SmartctlExporterDown** (warning after 30m): deliberately pages until the host-side install is done, so this cannot rot as a dormant scrape config

## One-time host-side step (I have no SSH access to the PVE host from the bastion -- verified)

On the Proxmox host:

1. Download smartctl_exporter v0.14.0 from https://github.com/prometheus-community/smartctl_exporter/releases into `/usr/local/bin/`
2. Systemd unit (root): `ExecStart=/usr/local/bin/smartctl_exporter --web.listen-address=:9633`
3. Verify from the bastion: `curl http://192.168.227.195:9633/metrics | grep smartctl_device_smart_status`

The same instructions live in the service manifest header so they survive next to the config they belong to.