### PR TITLE
fix(kube-system): pin generic-device-plugin resource domain to squat.ai

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/daemonset.yaml
@@ -27,6 +27,12 @@ spec:
           # manager rolls the digest, which a bare SHA tag can't get.
           image: ghcr.io/squat/generic-device-plugin:latest@sha256:dc192e164c69b03f156765793a1be62ca437709ae477b27ca7d8f3dcf5021576
           args:
+            # Newer builds renamed the default resource domain squat.ai ->
+            # devic.es, which silently unpublished squat.ai/tun and left
+            # gluetun unschedulable (2026-08-29). Pin the legacy domain the
+            # consumers request.
+            - --domain
+            - squat.ai
             - --device
             - |
               name: tun


### PR DESCRIPTION
The digest-tracked `latest` build renamed its default resource domain `squat.ai` → `devic.es`, which silently unpublished `squat.ai/tun` on all nodes — qbittorrent (gluetun needs the tun device) has been unschedulable since the hygiene merge. `--domain squat.ai` restores the advertised name. Found during post-upgrade verification.