### PR TITLE
fix(default): codify plex lan networks preference

### DIFF
--- a/kubernetes/apps/default/plex/app/helm-release.yaml
+++ b/kubernetes/apps/default/plex/app/helm-release.yaml
@@ -31,6 +31,14 @@ spec:
               TZ: Asia/Dubai
               PLEX_ADVERTISE_URL: http://192.168.227.206:32400
               PLEX_NO_AUTH_NETWORKS: 192.168.227.0/24,10.128.0.0/14
+              # The pod's own subnet is the cluster SDN, so with LAN Networks
+              # unset Plex classifies every real 192.168.227.x client as
+              # EXTERNAL — WAN bitrate caps + forced transcodes for streams
+              # that never leave the house (bit us 2026-08-29). The SDN range
+              # is included so Route/haproxy-proxied connections (source IP =
+              # router pod) stay local too. Applied by the image entrypoint
+              # on every start, so it also survives config-PVC restores.
+              PLEX_PREFERENCE_LAN_NETWORKS: LanNetworksBandwidth=192.168.227.0/24,10.128.0.0/14
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Codifies the live-applied `LanNetworksBandwidth=192.168.227.0/24,10.128.0.0/14` fix (LAN clients were classified external because the pod's own subnet is the SDN → WAN caps + forced transcodes on couch-distance streams). Uses the image's native `PLEX_PREFERENCE_*` entrypoint mechanism — upserted into Preferences.xml on every container start, so it survives restarts and config-PVC restores. Note: merging restarts the plex pod once (env change).