### PR TITLE
feat(rook-ceph): unreplicated cephfs scratch pool + storage class

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
@@ -45,6 +45,9 @@ spec:
           bdev_async_discard_threads: "1"
           osd_class_update_on_start: "false"
           device_failure_prediction_mode: local
+          # The cephfs scratch data pool below is deliberately size 1;
+          # without this Ceph pins HEALTH_WARN (POOL_NO_REDUNDANCY) forever.
+          mon_warn_on_pool_no_redundancy: "false"
       crashCollector:
         disable: false
       csi:
@@ -155,6 +158,19 @@ spec:
                 size: 3
                 requireSafeReplicaSize: true
               name: data0
+            # Unreplicated scratch pool for the shared downloads volume. That
+            # data is transient (re-downloadable partials, or completed files
+            # on their way to the NAS), and every OSD sits on the same single
+            # host NVMe as etcd and the OS disks — 3x replication there turned
+            # a 38 MiB/s download into ~115 MiB/s of physical writes and drove
+            # OSD commit latency to 200-500ms, stalling every ceph-block
+            # database (grafana, plex, ...). One copy is the right amount for
+            # scratch. Consumed via the ceph-filesystem-scratch StorageClass.
+            - failureDomain: host
+              replicated:
+                size: 1
+                requireSafeReplicaSize: false
+              name: scratch
           preserveFilesystemOnDelete: true
           metadataServer:
             activeCount: 1

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./oci-repository.yaml
   - ./helm-release.yaml
   - ./route.yaml
+  - ./storageclass-scratch.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/storageclass-scratch.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/storageclass-scratch.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/storage.k8s.io/storageclass_v1.json
+---
+# Companion to the rook-ceph-cluster chart's ceph-filesystem class, pointed at
+# the unreplicated `scratch` data pool declared on the okd-cephfs filesystem
+# (see helm-release.yaml). The chart can only render one StorageClass per
+# filesystem, so this one is declared by hand with identical CSI secrets.
+# Use ONLY for data you can afford to lose on a single disk failure.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-filesystem-scratch
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: rook-ceph.cephfs.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  fsName: okd-cephfs
+  pool: okd-cephfs-scratch
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: Immediate


### PR DESCRIPTION
Adds a `size: 1` `scratch` data pool to `okd-cephfs` and a hand-declared `ceph-filesystem-scratch` StorageClass (the chart renders only one SC per filesystem). Silences `POOL_NO_REDUNDANCY` via `cephConfig`.

**Why:** all OSDs share the one host NVMe with etcd + OS disks. Replicating the downloads scratch volume 3× turned 38 MiB/s of downloads into ~115 MiB/s of physical writes → OSD commit latency 200–500 ms → Grafana/Plex SQLite stalls. Downloads are transient; one copy is correct.

Non-disruptive: rook runs `ceph fs add_data_pool`, nothing moves. The `downloads` PVC is repointed in a follow-up PR after the sabnzbd queue drains.