### PR TITLE
fix(rook-ceph): rotate cephx daemon keys for CVE-2025-30156

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
@@ -37,6 +37,19 @@ spec:
       repository: quay.io/ceph/ceph
       tag: v20.2.4
     cephClusterSpec:
+      # CVE-2025-30156: Ceph 20.2.4 flags the legacy AES-128 cephx keys every
+      # daemon was created with (AUTH_INSECURE_*, two at ERR level). Rook
+      # v1.20.6+ rotates daemon keys declaratively — bump keyGeneration to
+      # rotate again. Rook auto-selects aes256k for daemons on 20.2.4.
+      # CSI (kernel-mount) keys are deliberately NOT rotated to aes256k: the
+      # cephfs/rbd kernel clients need Linux >= 7.0 for it and SCOS ships
+      # older, so AUTH_INSECURE_CLIENT_KEY_TYPE is expected to keep warning
+      # for the csi users — mute that one check rather than "fix" it.
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 1
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       cephConfig:


### PR DESCRIPTION
Declarative daemon key rotation via `spec.security.cephx.daemon` (Rook v1.20.6 + Ceph 20.2.4, both already on develop via the Renovate bump). Clears the ERR-level `AUTH_INSECURE_SERVICE_*` checks. Restarts MDS/RGW once. CSI keys intentionally left `aes` — SCOS kernels are below the 7.0 floor for aes256k kernel mounts — so `AUTH_INSECURE_CLIENT_KEY_TYPE` will remain for the csi users and gets muted. **Draft until the in-flight OSD 20.2.4 upgrade completes** (Rook rotates only after all daemons are on the new version).