### PR TITLE
fix(rook-ceph): cephx keyGeneration 2 — generation 1 is the birth generation

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph-cluster/app/helm-release.yaml
@@ -41,6 +41,9 @@ spec:
       # daemon was created with (AUTH_INSECURE_*, two at ERR level). Rook
       # v1.20.6+ rotates daemon keys declaratively — bump keyGeneration to
       # rotate again. Rook auto-selects aes256k for daemons on 20.2.4.
+      # Keys created at cluster birth already carry generation 1 and Rook
+      # rotates only when the declared generation EXCEEDS the current one,
+      # so the first real rotation is generation 2.
       # CSI (kernel-mount) keys are deliberately NOT rotated to aes256k: the
       # cephfs/rbd kernel clients need Linux >= 7.0 for it and SCOS ships
       # older, so AUTH_INSECURE_CLIENT_KEY_TYPE is expected to keep warning
@@ -49,7 +52,7 @@ spec:
         cephx:
           daemon:
             keyRotationPolicy: KeyGeneration
-            keyGeneration: 1
+            keyGeneration: 2
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       cephConfig:


### PR DESCRIPTION
Follow-up to #217: birth keys already sit at generation 1 and Rook only rotates on generation > current, so #217 rotated only the admin key. Generation 2 triggers the real daemon rotation (mon/mgr/osd/mds/rgw → aes256k on 20.2.4). Rolling daemon restarts.